### PR TITLE
Extend checks supported events

### DIFF
--- a/lib/actions/checks.js
+++ b/lib/actions/checks.js
@@ -64,19 +64,8 @@ class Checks extends Action {
   constructor () {
     super('checks')
     this.supportedEvents = [
-      'pull_request.opened',
-      'pull_request.edited',
-      'pull_request_review.submitted',
-      'pull_request_review.edited',
-      'pull_request_review.dismissed',
-      'pull_request.labeled',
-      'pull_request.milestoned',
-      'pull_request.demilestoned',
-      'pull_request.assigned',
-      'pull_request.unassigned',
-      'pull_request.unlabeled',
-      'pull_request.synchronize',
-      'pull_request.push_synchronize'
+      'pull_request.*',
+      'pull_request_review.*'
     ]
     this.checkRunResult = new Map()
   }


### PR DESCRIPTION
The checks action should be able to support every pull_request and
pull_request_review events like stated in the documentation.
For example support for some events like pull_request.ready_for_review
was not supported with current implementation.